### PR TITLE
Add ${database} to MongoClient url

### DIFF
--- a/utils/db.js
+++ b/utils/db.js
@@ -4,7 +4,7 @@ const host = process.env.DB_HOST || 'localhost';
 const port = process.env.DB_PORT || 27017;
 const database = process.env.DB_DATABASE || 'files_manager';
 
-const url = `mongodb://${host}:${port}`;
+const url = `mongodb://${host}:${port}/${database}`;
 
 class DBClient {
   constructor() {


### PR DESCRIPTION
Looking at the test file for the first check that we are missing on Task 3, notice how they have ${dbInfo.database} at the end of their url connection string. We did NOT have that in db.js, so I added it.

For reference:

const { MongoClient } = require('mongodb');

const host = process.env.DB_HOST || 'localhost';
const port = process.env.DB_PORT || 27017;
const database = process.env.DB_DATABASE || 'files_manager';

const url = `mongodb://${host}:${port}/${database}`;